### PR TITLE
Directorio `env ` en Modulo2Katas

### DIFF
--- a/Módulo 2 - Crear y administrar proyectos/Modulo2Katas.md
+++ b/Módulo 2 - Crear y administrar proyectos/Modulo2Katas.md
@@ -20,7 +20,7 @@ Crea un entorno virtual mediante ``venv``
     ```
     source env/bin/activate
     # Windows
-    env\bin\activate
+    env\bin\activate o env\scripts\activate
 
     # Linux, WSL or macOS
     source env/bin/activate


### PR DESCRIPTION
En mi caso el directorio de `env` tenia una estrucuta diferente (no se encontraba env\bin\activate) en su lugar estaba env/scripts/activate, estoy usando el SO Windows.