### PR TITLE
Cambio de a %pip install matplotlib

### DIFF
--- a/Módulo 0 - Preparación del entorno de trabajo/Módulo 0 - Preparación del entorno de trabajo.md
+++ b/Módulo 0 - Preparación del entorno de trabajo/Módulo 0 - Preparación del entorno de trabajo.md
@@ -160,7 +160,7 @@ Crea un gráfico para mostrar los niveles de oxígeno de su nave utilizando ``Ma
 Para ello en una celda de código vamos a ejecutar el siguiente comando:
 
 ```
-    !pip install matplotlib
+    %pip install matplotlib
     !pip install numpy
 ```
 


### PR DESCRIPTION
En la consola de VScode se suguiere un `%pip install matplotlib` en lugar de `!pip install matplotlib` lo que resulve el error al intentar presentar las graficas