### PR TITLE
Corrección de activación de venv en Windows

### DIFF
--- a/Módulo 2 - Crear y administrar proyectos/Modulo2Katas.md
+++ b/Módulo 2 - Crear y administrar proyectos/Modulo2Katas.md
@@ -19,8 +19,11 @@ Crea un entorno virtual mediante ``venv``
 
     ```
     source env/bin/activate
-    # Windows
-    env\bin\activate
+    # Windows cmd.exe
+    env\Scripts\activate.bat
+    
+    # Windows PowerShell
+    env\Scripts\Activate.ps1
 
     # Linux, WSL or macOS
     source env/bin/activate


### PR DESCRIPTION
De acuerdo con la [documentación oficial](https://docs.python.org/es/3/library/venv.html) el archivo de activación en Windows se encuentra en la carpeta Scripts en lugar de bin.