### PR TITLE
Actualizar path para actualización de venv

### DIFF
--- a/Módulo 2 - Crear y administrar proyectos/Módulo 2 - Crear y administrar proyectos.md
+++ b/Módulo 2 - Crear y administrar proyectos/Módulo 2 - Crear y administrar proyectos.md
@@ -83,7 +83,7 @@ Así es como puede verse la activación en distintos sistemas operativos.
 ```
   # Bash | Consola
   # Windows
-  env\bin\activate
+  env\Scripts\activate
 
   # Linux, WSL o macOS
   source env/bin/activate


### PR DESCRIPTION
De acuerdo con la [documentación oficial](https://docs.python.org/es/3/library/venv.html) el archivo de activación en Windows se encuentra en la carpeta Scripts en lugar de bin.