### PR TITLE
Create kata 0

### DIFF
--- a/Módulo 0 - Preparación del entorno de trabajo/kata 0
+++ b/Módulo 0 - Preparación del entorno de trabajo/kata 0
@@ -1,0 +1,295 @@
+@@ -1,109 +1,109 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ejercicio: crerar y ejecutar mi notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instalar la bibllioteca:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: ipywidgets in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (7.6.5)\n",
+      "Requirement already satisfied: traitlets>=4.3.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (5.1.1)\n",
+      "Requirement already satisfied: nbformat>=4.2.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (5.1.3)\n",
+      "Requirement already satisfied: ipython>=4.0.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (8.0.1)\n",
+      "Requirement already satisfied: ipython-genutils~=0.2.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (0.2.0)\n",
+      "Requirement already satisfied: widgetsnbextension~=3.5.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (3.5.2)\n",
+      "Requirement already satisfied: jupyterlab-widgets>=1.0.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (1.0.2)\n",
+      "Requirement already satisfied: ipykernel>=4.5.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (6.9.0)\n",
+      "Requirement already satisfied: nest-asyncio in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipykernel>=4.5.1->ipywidgets) (1.5.4)\n",
+      "Requirement already satisfied: debugpy<2.0,>=1.0.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipykernel>=4.5.1->ipywidgets) (1.5.1)\n",
+      "Requirement already satisfied: jupyter-client<8.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipykernel>=4.5.1->ipywidgets) (7.1.2)\n",
+      "Requirement already satisfied: tornado<7.0,>=4.2 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipykernel>=4.5.1->ipywidgets) (6.1)\n",
+      "Requirement already satisfied: matplotlib-inline<0.2.0,>=0.1.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipykernel>=4.5.1->ipywidgets) (0.1.3)\n",
+      "Requirement already satisfied: jedi>=0.16 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (0.18.1)\n",
+      "Requirement already satisfied: pickleshare in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (0.7.5)\n",
+      "Requirement already satisfied: decorator in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (5.1.1)\n",
+      "Requirement already satisfied: setuptools>=18.5 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (58.1.0)\n",
+      "Requirement already satisfied: pygments in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (2.11.2)\n",
+      "Requirement already satisfied: colorama in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (0.4.4)\n",
+      "Requirement already satisfied: prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (3.0.27)\n",
+      "Requirement already satisfied: backcall in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (0.2.0)\n",
+      "Requirement already satisfied: black in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (22.1.0)\n",
+      "Requirement already satisfied: stack-data in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (0.1.4)\n",
+      "Requirement already satisfied: jupyter-core in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbformat>=4.2.0->ipywidgets) (4.9.1)\n",
+      "Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbformat>=4.2.0->ipywidgets) (4.4.0)\n",
+      "Requirement already satisfied: notebook>=4.4.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from widgetsnbextension~=3.5.0->ipywidgets) (6.4.8)\n",
+      "Requirement already satisfied: parso<0.9.0,>=0.8.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jedi>=0.16->ipython>=4.0.0->ipywidgets) (0.8.3)\n",
+      "Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets) (0.18.1)\n",
+      "Requirement already satisfied: attrs>=17.4.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets) (21.4.0)\n",
+      "Requirement already satisfied: entrypoints in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets) (0.4)\n",
+      "Requirement already satisfied: python-dateutil>=2.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets) (2.8.2)\n",
+      "Requirement already satisfied: pyzmq>=13 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets) (22.3.0)\n",
+      "Requirement already satisfied: pywin32>=1.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jupyter-core->nbformat>=4.2.0->ipywidgets) (303)\n",
+      "Requirement already satisfied: Send2Trash>=1.8.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (1.8.0)\n",
+      "Requirement already satisfied: argon2-cffi in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (21.3.0)\n",
+      "Requirement already satisfied: prometheus-client in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.13.1)\n",
+      "Requirement already satisfied: jinja2 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (3.0.3)\n",
+      "Requirement already satisfied: nbconvert in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (6.4.2)\n",
+      "Requirement already satisfied: terminado>=0.8.3 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.13.1)\n",
+      "Requirement already satisfied: wcwidth in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0->ipython>=4.0.0->ipywidgets) (0.2.5)\n",
+      "Requirement already satisfied: pathspec>=0.9.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from black->ipython>=4.0.0->ipywidgets) (0.9.0)\n",
+      "Requirement already satisfied: click>=8.0.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from black->ipython>=4.0.0->ipywidgets) (8.0.3)\n",
+      "Requirement already satisfied: platformdirs>=2 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from black->ipython>=4.0.0->ipywidgets) (2.5.0)\n",
+      "Requirement already satisfied: tomli>=1.1.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from black->ipython>=4.0.0->ipywidgets) (2.0.1)\n",
+      "Requirement already satisfied: mypy-extensions>=0.4.3 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from black->ipython>=4.0.0->ipywidgets) (0.4.3)\n",
+      "Requirement already satisfied: pure-eval in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from stack-data->ipython>=4.0.0->ipywidgets) (0.2.2)\n",
+      "Requirement already satisfied: asttokens in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from stack-data->ipython>=4.0.0->ipywidgets) (2.0.5)\n",
+      "Requirement already satisfied: executing in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from stack-data->ipython>=4.0.0->ipywidgets) (0.8.2)\n",
+      "Requirement already satisfied: six>=1.5 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from python-dateutil>=2.1->jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets) (1.16.0)\n",
+      "Requirement already satisfied: pywinpty>=1.1.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from terminado>=0.8.3->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (2.0.2)\n",
+      "Requirement already satisfied: argon2-cffi-bindings in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (21.2.0)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jinja2->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (2.0.1)\n",
+      "Requirement already satisfied: nbclient<0.6.0,>=0.5.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.5.10)\n",
+      "Requirement already satisfied: bleach in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (4.1.0)\n",
+      "Requirement already satisfied: defusedxml in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.7.1)\n",
+      "Requirement already satisfied: mistune<2,>=0.8.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.8.4)\n",
+      "Requirement already satisfied: pandocfilters>=1.4.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (1.5.0)\n",
+      "Requirement already satisfied: testpath in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.5.0)\n",
+      "Requirement already satisfied: jupyterlab-pygments in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.1.2)\n",
+      "Requirement already satisfied: cffi>=1.0.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from argon2-cffi-bindings->argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (1.15.0)\n",
+      "Requirement already satisfied: webencodings in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.5.1)\n",
+      "Requirement already satisfied: packaging in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (21.3)\n",
+      "Requirement already satisfied: pycparser in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from cffi>=1.0.1->argon2-cffi-bindings->argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (2.21)\n",
+      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from packaging->bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (3.0.7)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "pip install ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4bcf626c20604e469cc4639a20da6dd2",
+       "model_id": "2c43ced0c8a4415fb796c65cd21bbc97",
+       "version_major": 2,
+       "version_minor": 0
+      },
+@@ -117,7 +117,7 @@
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e31c423b6e8c4e55a26986ea5bf9a447",
+       "model_id": "ceb9817bbb304a16aa737541dfce77a3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "\n",
+    "ignition = widgets.ToggleButton(\n",
+    "    value=False,\n",
+    "    description='Iniciar Launch',\n",
+    "    button_style='success',\n",
+    "    tooltip='Engage your Launch',\n",
+    "    icon='rocket'\n",
+    ")\n",
+    "\n",
+    "output = widgets.Output()\n",
+    "\n",
+    "display(ignition, output)\n",
+    "\n",
+    "def on_value_change(change):\n",
+    "    with output:\n",
+    "        if change['new'] == True:\n",
+    "            print(\"Nave Iniciada!\")\n",
+    "        else:   \n",
+    "            print(\"Nave Detenida\")\n",
+    "\n",
+    "ignition.observe(on_value_change, names='value')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ejercicio 2: Comandos avanzados"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting matplotlib\n",
+      "  Downloading matplotlib-3.5.1-cp310-cp310-win_amd64.whl (7.2 MB)\n",
+      "     ---------------------------------------- 7.2/7.2 MB 6.1 MB/s eta 0:00:00\n",
+      "Requirement already satisfied: packaging>=20.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib) (21.3)\n",
+      "Collecting cycler>=0.10\n",
+      "  Downloading cycler-0.11.0-py3-none-any.whl (6.4 kB)\n",
+      "Collecting numpy>=1.17\n",
+      "  Downloading numpy-1.22.2-cp310-cp310-win_amd64.whl (14.7 MB)\n",
+      "     ---------------------------------------- 14.7/14.7 MB 7.0 MB/s eta 0:00:00\n",
+      "Requirement already satisfied: pyparsing>=2.2.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib) (3.0.7)\n",
+      "Collecting pillow>=6.2.0\n",
+      "  Downloading Pillow-9.0.1-cp310-cp310-win_amd64.whl (3.2 MB)\n",
+      "     ---------------------------------------- 3.2/3.2 MB 8.3 MB/s eta 0:00:00\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib) (2.8.2)\n",
+      "Collecting fonttools>=4.22.0\n",
+      "  Downloading fonttools-4.29.1-py3-none-any.whl (895 kB)\n",
+      "     -------------------------------------- 895.5/895.5 KB 8.1 MB/s eta 0:00:00\n",
+      "Collecting kiwisolver>=1.0.1\n",
+      "  Downloading kiwisolver-1.3.2-cp310-cp310-win_amd64.whl (52 kB)\n",
+      "     ---------------------------------------- 52.1/52.1 KB 2.6 MB/s eta 0:00:00\n",
+      "Requirement already satisfied: six>=1.5 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from python-dateutil>=2.7->matplotlib) (1.16.0)\n",
+      "Installing collected packages: pillow, numpy, kiwisolver, fonttools, cycler, matplotlib\n",
+      "Successfully installed cycler-0.11.0 fonttools-4.29.1 kiwisolver-1.3.2 matplotlib-3.5.1 numpy-1.22.2 pillow-9.0.1\n",
+      "Requirement already satisfied: numpy in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (1.22.2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install matplotlib\n",
+    "!pip install numpy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Niveles de Oxígeno\n",
+    "Muestra diez minutos de niveles de oxígeno en tu nave. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAKFklEQVR4nO3dT6ilB3nH8d/TjKKJRYXcjUmmN4uSEgSJXNpowEXiwnZENy5SSKBCmU3VKIKM3bjNQkQXRRhi3Rh0MWZRTLEW1EU3oTNJQJNRkDjNHyOOC/+QTQw+Xdw76XSYZE5k3nOeO+fzgYE557z3vM9759wv733P+86p7g4Ac/3ZpgcA4PUJNcBwQg0wnFADDCfUAMMdWeJJb7zxxt7d3V3iqQGuSWfOnPl1d+9c7rFFQr27u5vTp08v8dQA16Sq+p/XesyhD4DhhBpgOKEGGE6oAYYTaoDhhBpgOKEGGE6oAYYTaoDhFrkyEeBydk88uvg6zj14bPF1rJs9aoDhhBpgOKEGGE6oAYYTaoDhhBpgOKEGGE6oAYYTaoDhhBpgOKEGGE6oAYYTaoDhhBpgOKEGGE6oAYYTaoDhhBpgOKEGGG6lUFfVZ6rqqar6cVV9s6resvRgAOy7Yqir6qYkn0qy193vTnJdknuXHgyAfase+jiS5K1VdSTJ9Ul+sdxIAFzsiqHu7heSfDHJs0leTPLb7v7epctV1fGqOl1Vp8+fP3/1JwXYUqsc+nhnko8muTXJu5LcUFX3Xbpcd5/s7r3u3tvZ2bn6kwJsqVUOfXwwyc+7+3x3/yHJI0nev+xYAFywSqifTXJnVV1fVZXkniRnlx0LgAtWOUb9WJJTSR5P8qODrzm58FwAHDiyykLd/YUkX1h4FgAuw5WJAMMJNcBwQg0wnFADDCfUAMMJNcBwQg0wnFADDCfUAMMJNcBwQg0wnFADDCfUAMMJNcBwQg0wnFADDCfUAMOt9AkvLG/3xKOLr+Pcg8cWX8dh4nvOYWGPGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhlsp1FX1jqo6VVU/qaqzVfW+pQcDYN+qH277lSTf7e6PVdWbk1y/4EwAXOSKoa6qtyf5QJJ/SJLufjnJy8uOBcAFq+xR35rkfJKvV9V7kpxJ8kB3v3TxQlV1PMnxJDl69OifPNDuiUf/5K9d1bkHjy2+Dng9m3yd+xk7fFY5Rn0kyXuTfLW770jyUpITly7U3Se7e6+793Z2dq7ymADba5VQP5/k+e5+7OD2qeyHG4A1uGKou/uXSZ6rqtsO7ronydOLTgXAq1Y96+OTSR4+OOPjmSQfX24kAC62Uqi7+8kke8uOAsDluDIRYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYLiVQ11V11XVE1X1nSUHAuD/eyN71A8kObvUIABc3kqhrqqbkxxL8tCy4wBwqVX3qL+c5HNJ/vhaC1TV8ao6XVWnz58/fzVmAyArhLqqPpzkV9195vWW6+6T3b3X3Xs7OztXbUCAbbfKHvVdST5SVeeSfCvJ3VX1jUWnAuBVVwx1d3++u2/u7t0k9yb5fnfft/hkACRxHjXAeEfeyMLd/cMkP1xkEgAuyx41wHBCDTCcUAMMJ9QAwwk1wHBCDTCcUAMMJ9QAwwk1wHBCDTCcUAMMJ9QAwwk1wHBCDTCcUAMMJ9QAwwk1wHBv6BNeuDbtnnh08XWce/DY4uuA13OYX+f2qAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYLgrhrqqbqmqH1TV01X1VFU9sI7BANi3yofbvpLks939eFX9eZIzVfWf3f30wrMBkBX2qLv7xe5+/ODvv09yNslNSw8GwL5V9qhfVVW7Se5I8thlHjue5HiSHD169GrMtnaH+ePkDyvfc7iyld9MrKq3Jfl2kk939+8ufby7T3b3Xnfv7ezsXM0ZAbbaSqGuqjdlP9IPd/cjy44EwMVWOeujknwtydnu/tLyIwFwsVX2qO9Kcn+Su6vqyYM/f7fwXAAcuOKbid39X0lqDbMAcBmuTAQYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYbqVQV9WHquqnVfWzqjqx9FAA/J8rhrqqrkvyL0n+NsntSf6+qm5fejAA9q2yR/3XSX7W3c9098tJvpXko8uOBcAF1d2vv0DVx5J8qLv/8eD2/Un+prs/cclyx5McP7h5W5KfXv1xL+vGJL9e07omsd3bZ1u3fVu2+y+6e+dyDxy5Wmvo7pNJTl6t51tVVZ3u7r11r3fTbPf22dZt39btvtgqhz5eSHLLRbdvPrgPgDVYJdT/neQvq+rWqnpzknuT/NuyYwFwwRUPfXT3K1X1iST/keS6JP/a3U8tPtnq1n64ZQjbvX22ddu3dbtfdcU3EwHYLFcmAgwn1ADDHepQb+Ol7VV1S1X9oKqerqqnquqBTc+0TlV1XVU9UVXf2fQs61JV76iqU1X1k6o6W1Xv2/RM61BVnzl4jf+4qr5ZVW/Z9EybcmhDvcWXtr+S5LPdfXuSO5P805Zs9wUPJDm76SHW7CtJvtvdf5XkPdmC7a+qm5J8Ksled787+ycy3LvZqTbn0IY6W3ppe3e/2N2PH/z999n/ob1ps1OtR1XdnORYkoc2Pcu6VNXbk3wgydeSpLtf7u7fbHSo9TmS5K1VdSTJ9Ul+seF5NuYwh/qmJM9ddPv5bEmwLqiq3SR3JHlsw6Osy5eTfC7JHzc8xzrdmuR8kq8fHPJ5qKpu2PRQS+vuF5J8McmzSV5M8tvu/t5mp9qcwxzqrVZVb0vy7SSf7u7fbXqepVXVh5P8qrvPbHqWNTuS5L1JvtrddyR5Kck1/35MVb0z+78h35rkXUluqKr7NjvV5hzmUG/tpe1V9absR/rh7n5k0/OsyV1JPlJV57J/mOvuqvrGZkdai+eTPN/dF35rOpX9cF/rPpjk5919vrv/kOSRJO/f8Ewbc5hDvZWXtldVZf945dnu/tKm51mX7v58d9/c3bvZ/7f+fndf83tY3f3LJM9V1W0Hd92T5OkNjrQuzya5s6quP3jN35MteBP1tVy1/z1v3Q7Bpe1LuSvJ/Ul+VFVPHtz3z93975sbiYV9MsnDBzskzyT5+IbnWVx3P1ZVp5I8nv0znZ7IFl9K7hJygOEO86EPgK0g1ADDCTXAcEINMJxQAwwn1ADDCTXAcP8LfGMTn5mMWBMAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "data = np.random.default_rng(12345)\n",
+    "oxy_nums = data.integers(low=0, high=10, size=10)\n",
+    "\n",
+    "plt.bar(range(len(oxy_nums)), oxy_nums)\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Velocidad de la nave\n",
+    "Muestra los segundos necesarios para pasar de 0 a 11200 metros por segundo, dada la aceleración de la nave en metros por segundo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tiempo en segundos para alcanzar la velocidad deseada =  1142.8571428571427\n"
+     ]
+    }
+   ],
+   "source": [
+    "endVelocity = 11200\n",
+    "startVelocity = 0\n",
+    "acceleration = 9.8\n",
+    "\n",
+    "time = (endVelocity - startVelocity) / acceleration\n",
+    "print(\"Tiempo en segundos para alcanzar la velocidad deseada = \", time)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "f779eca3a750bafcf59e051e0cedc42f23938d3a08e4ac3411a467126037adc3"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.10.2 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.2"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
[](https://github.com/RicardoUMC/KatasRicardoMoraLaunchX/commit/93d04f7600848f7626407b93ef6633ff8b384ca3#diff-487f868faa48bdd44e48ae2a3dcacdb51a950ab04a3af02f909f5b00c14c4c20)@@ -1,109 +1,109 @@
{
 "cells": [
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "## Ejercicio: crerar y ejecutar mi notebook"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "Instalar la bibllioteca:"
   ]
  },
  {
   "cell_type": "code",
   "execution_count": 1,
   "metadata": {},
   "outputs": [
    {
     "name": "stdout",
     "output_type": "stream",
     "text": [
      "Requirement already satisfied: ipywidgets in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (7.6.5)\n",
      "Requirement already satisfied: traitlets>=4.3.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (5.1.1)\n",
      "Requirement already satisfied: nbformat>=4.2.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (5.1.3)\n",
      "Requirement already satisfied: ipython>=4.0.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (8.0.1)\n",
      "Requirement already satisfied: ipython-genutils~=0.2.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (0.2.0)\n",
      "Requirement already satisfied: widgetsnbextension~=3.5.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (3.5.2)\n",
      "Requirement already satisfied: jupyterlab-widgets>=1.0.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (1.0.2)\n",
      "Requirement already satisfied: ipykernel>=4.5.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipywidgets) (6.9.0)\n",
      "Requirement already satisfied: nest-asyncio in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipykernel>=4.5.1->ipywidgets) (1.5.4)\n",
      "Requirement already satisfied: debugpy<2.0,>=1.0.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipykernel>=4.5.1->ipywidgets) (1.5.1)\n",
      "Requirement already satisfied: jupyter-client<8.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipykernel>=4.5.1->ipywidgets) (7.1.2)\n",
      "Requirement already satisfied: tornado<7.0,>=4.2 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipykernel>=4.5.1->ipywidgets) (6.1)\n",
      "Requirement already satisfied: matplotlib-inline<0.2.0,>=0.1.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipykernel>=4.5.1->ipywidgets) (0.1.3)\n",
      "Requirement already satisfied: jedi>=0.16 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (0.18.1)\n",
      "Requirement already satisfied: pickleshare in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (0.7.5)\n",
      "Requirement already satisfied: decorator in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (5.1.1)\n",
      "Requirement already satisfied: setuptools>=18.5 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (58.1.0)\n",
      "Requirement already satisfied: pygments in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (2.11.2)\n",
      "Requirement already satisfied: colorama in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (0.4.4)\n",
      "Requirement already satisfied: prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (3.0.27)\n",
      "Requirement already satisfied: backcall in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (0.2.0)\n",
      "Requirement already satisfied: black in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (22.1.0)\n",
      "Requirement already satisfied: stack-data in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from ipython>=4.0.0->ipywidgets) (0.1.4)\n",
      "Requirement already satisfied: jupyter-core in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbformat>=4.2.0->ipywidgets) (4.9.1)\n",
      "Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbformat>=4.2.0->ipywidgets) (4.4.0)\n",
      "Requirement already satisfied: notebook>=4.4.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from widgetsnbextension~=3.5.0->ipywidgets) (6.4.8)\n",
      "Requirement already satisfied: parso<0.9.0,>=0.8.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jedi>=0.16->ipython>=4.0.0->ipywidgets) (0.8.3)\n",
      "Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets) (0.18.1)\n",
      "Requirement already satisfied: attrs>=17.4.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jsonschema!=2.5.0,>=2.4->nbformat>=4.2.0->ipywidgets) (21.4.0)\n",
      "Requirement already satisfied: entrypoints in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets) (0.4)\n",
      "Requirement already satisfied: python-dateutil>=2.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets) (2.8.2)\n",
      "Requirement already satisfied: pyzmq>=13 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets) (22.3.0)\n",
      "Requirement already satisfied: pywin32>=1.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jupyter-core->nbformat>=4.2.0->ipywidgets) (303)\n",
      "Requirement already satisfied: Send2Trash>=1.8.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (1.8.0)\n",
      "Requirement already satisfied: argon2-cffi in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (21.3.0)\n",
      "Requirement already satisfied: prometheus-client in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.13.1)\n",
      "Requirement already satisfied: jinja2 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (3.0.3)\n",
      "Requirement already satisfied: nbconvert in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (6.4.2)\n",
      "Requirement already satisfied: terminado>=0.8.3 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.13.1)\n",
      "Requirement already satisfied: wcwidth in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0->ipython>=4.0.0->ipywidgets) (0.2.5)\n",
      "Requirement already satisfied: pathspec>=0.9.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from black->ipython>=4.0.0->ipywidgets) (0.9.0)\n",
      "Requirement already satisfied: click>=8.0.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from black->ipython>=4.0.0->ipywidgets) (8.0.3)\n",
      "Requirement already satisfied: platformdirs>=2 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from black->ipython>=4.0.0->ipywidgets) (2.5.0)\n",
      "Requirement already satisfied: tomli>=1.1.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from black->ipython>=4.0.0->ipywidgets) (2.0.1)\n",
      "Requirement already satisfied: mypy-extensions>=0.4.3 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from black->ipython>=4.0.0->ipywidgets) (0.4.3)\n",
      "Requirement already satisfied: pure-eval in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from stack-data->ipython>=4.0.0->ipywidgets) (0.2.2)\n",
      "Requirement already satisfied: asttokens in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from stack-data->ipython>=4.0.0->ipywidgets) (2.0.5)\n",
      "Requirement already satisfied: executing in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from stack-data->ipython>=4.0.0->ipywidgets) (0.8.2)\n",
      "Requirement already satisfied: six>=1.5 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from python-dateutil>=2.1->jupyter-client<8.0->ipykernel>=4.5.1->ipywidgets) (1.16.0)\n",
      "Requirement already satisfied: pywinpty>=1.1.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from terminado>=0.8.3->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (2.0.2)\n",
      "Requirement already satisfied: argon2-cffi-bindings in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (21.2.0)\n",
      "Requirement already satisfied: MarkupSafe>=2.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jinja2->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (2.0.1)\n",
      "Requirement already satisfied: nbclient<0.6.0,>=0.5.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.5.10)\n",
      "Requirement already satisfied: bleach in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (4.1.0)\n",
      "Requirement already satisfied: defusedxml in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.7.1)\n",
      "Requirement already satisfied: mistune<2,>=0.8.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.8.4)\n",
      "Requirement already satisfied: pandocfilters>=1.4.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (1.5.0)\n",
      "Requirement already satisfied: testpath in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.5.0)\n",
      "Requirement already satisfied: jupyterlab-pygments in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.1.2)\n",
      "Requirement already satisfied: cffi>=1.0.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from argon2-cffi-bindings->argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (1.15.0)\n",
      "Requirement already satisfied: webencodings in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (0.5.1)\n",
      "Requirement already satisfied: packaging in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (21.3)\n",
      "Requirement already satisfied: pycparser in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from cffi>=1.0.1->argon2-cffi-bindings->argon2-cffi->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (2.21)\n",
      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from packaging->bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets) (3.0.7)\n",
      "Note: you may need to restart the kernel to use updated packages.\n"
     ]
    }
   ],
   "source": [
    "pip install ipywidgets"
   ]
  },
  {
   "cell_type": "code",
   "execution_count": 2,
   "execution_count": 1,
   "metadata": {},
   "outputs": [
    {
     "data": {
      "application/vnd.jupyter.widget-view+json": {
       "model_id": "4bcf626c20604e469cc4639a20da6dd2",
       "model_id": "2c43ced0c8a4415fb796c65cd21bbc97",
       "version_major": 2,
       "version_minor": 0
      },
@@ -117,7 +117,7 @@
    {
     "data": {
      "application/vnd.jupyter.widget-view+json": {
       "model_id": "e31c423b6e8c4e55a26986ea5bf9a447",
       "model_id": "ceb9817bbb304a16aa737541dfce77a3",
       "version_major": 2,
       "version_minor": 0
      },
      "text/plain": [
       "Output()"
      ]
     },
     "metadata": {},
     "output_type": "display_data"
    }
   ],
   "source": [
    "import ipywidgets as widgets\n",
    "\n",
    "ignition = widgets.ToggleButton(\n",
    "    value=False,\n",
    "    description='Iniciar Launch',\n",
    "    button_style='success',\n",
    "    tooltip='Engage your Launch',\n",
    "    icon='rocket'\n",
    ")\n",
    "\n",
    "output = widgets.Output()\n",
    "\n",
    "display(ignition, output)\n",
    "\n",
    "def on_value_change(change):\n",
    "    with output:\n",
    "        if change['new'] == True:\n",
    "            print(\"Nave Iniciada!\")\n",
    "        else:   \n",
    "            print(\"Nave Detenida\")\n",
    "\n",
    "ignition.observe(on_value_change, names='value')"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "## Ejercicio 2: Comandos avanzados"
   ]
  },
  {
   "cell_type": "code",
   "execution_count": null,
   "metadata": {},
   "outputs": [
    {
     "name": "stdout",
     "output_type": "stream",
     "text": [
      "Collecting matplotlib\n",
      "  Downloading matplotlib-3.5.1-cp310-cp310-win_amd64.whl (7.2 MB)\n",
      "     ---------------------------------------- 7.2/7.2 MB 6.1 MB/s eta 0:00:00\n",
      "Requirement already satisfied: packaging>=20.0 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib) (21.3)\n",
      "Collecting cycler>=0.10\n",
      "  Downloading cycler-0.11.0-py3-none-any.whl (6.4 kB)\n",
      "Collecting numpy>=1.17\n",
      "  Downloading numpy-1.22.2-cp310-cp310-win_amd64.whl (14.7 MB)\n",
      "     ---------------------------------------- 14.7/14.7 MB 7.0 MB/s eta 0:00:00\n",
      "Requirement already satisfied: pyparsing>=2.2.1 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib) (3.0.7)\n",
      "Collecting pillow>=6.2.0\n",
      "  Downloading Pillow-9.0.1-cp310-cp310-win_amd64.whl (3.2 MB)\n",
      "     ---------------------------------------- 3.2/3.2 MB 8.3 MB/s eta 0:00:00\n",
      "Requirement already satisfied: python-dateutil>=2.7 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib) (2.8.2)\n",
      "Collecting fonttools>=4.22.0\n",
      "  Downloading fonttools-4.29.1-py3-none-any.whl (895 kB)\n",
      "     -------------------------------------- 895.5/895.5 KB 8.1 MB/s eta 0:00:00\n",
      "Collecting kiwisolver>=1.0.1\n",
      "  Downloading kiwisolver-1.3.2-cp310-cp310-win_amd64.whl (52 kB)\n",
      "     ---------------------------------------- 52.1/52.1 KB 2.6 MB/s eta 0:00:00\n",
      "Requirement already satisfied: six>=1.5 in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from python-dateutil>=2.7->matplotlib) (1.16.0)\n",
      "Installing collected packages: pillow, numpy, kiwisolver, fonttools, cycler, matplotlib\n",
      "Successfully installed cycler-0.11.0 fonttools-4.29.1 kiwisolver-1.3.2 matplotlib-3.5.1 numpy-1.22.2 pillow-9.0.1\n",
      "Requirement already satisfied: numpy in c:\\users\\rumc-\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (1.22.2)\n"
     ]
    }
   ],
   "source": [
    "!pip install matplotlib\n",
    "!pip install numpy"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "### Niveles de Oxígeno\n",
    "Muestra diez minutos de niveles de oxígeno en tu nave. "
   ]
  },
  {
   "cell_type": "code",
   "execution_count": 3,
   "metadata": {},
   "outputs": [
    {
     "data": {
      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAKFklEQVR4nO3dT6ilB3nH8d/TjKKJRYXcjUmmN4uSEgSJXNpowEXiwnZENy5SSKBCmU3VKIKM3bjNQkQXRRhi3Rh0MWZRTLEW1EU3oTNJQJNRkDjNHyOOC/+QTQw+Xdw76XSYZE5k3nOeO+fzgYE557z3vM9759wv733P+86p7g4Ac/3ZpgcA4PUJNcBwQg0wnFADDCfUAMMdWeJJb7zxxt7d3V3iqQGuSWfOnPl1d+9c7rFFQr27u5vTp08v8dQA16Sq+p/XesyhD4DhhBpgOKEGGE6oAYYTaoDhhBpgOKEGGE6oAYYTaoDhFrkyEeBydk88uvg6zj14bPF1rJs9aoDhhBpgOKEGGE6oAYYTaoDhhBpgOKEGGE6oAYYTaoDhhBpgOKEGGE6oAYYTaoDhhBpgOKEGGE6oAYYTaoDhhBpgOKEGGG6lUFfVZ6rqqar6cVV9s6resvRgAOy7Yqir6qYkn0qy193vTnJdknuXHgyAfase+jiS5K1VdSTJ9Ul+sdxIAFzsiqHu7heSfDHJs0leTPLb7v7epctV1fGqOl1Vp8+fP3/1JwXYUqsc+nhnko8muTXJu5LcUFX3Xbpcd5/s7r3u3tvZ2bn6kwJsqVUOfXwwyc+7+3x3/yHJI0nev+xYAFywSqifTXJnVV1fVZXkniRnlx0LgAtWOUb9WJJTSR5P8qODrzm58FwAHDiyykLd/YUkX1h4FgAuw5WJAMMJNcBwQg0wnFADDCfUAMMJNcBwQg0wnFADDCfUAMMJNcBwQg0wnFADDCfUAMMJNcBwQg0wnFADDCfUAMOt9AkvLG/3xKOLr+Pcg8cWX8dh4nvOYWGPGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhlsp1FX1jqo6VVU/qaqzVfW+pQcDYN+qH277lSTf7e6PVdWbk1y/4EwAXOSKoa6qtyf5QJJ/SJLufjnJy8uOBcAFq+xR35rkfJKvV9V7kpxJ8kB3v3TxQlV1PMnxJDl69OifPNDuiUf/5K9d1bkHjy2+Dng9m3yd+xk7fFY5Rn0kyXuTfLW770jyUpITly7U3Se7e6+793Z2dq7ymADba5VQP5/k+e5+7OD2qeyHG4A1uGKou/uXSZ6rqtsO7ronydOLTgXAq1Y96+OTSR4+OOPjmSQfX24kAC62Uqi7+8kke8uOAsDluDIRYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYLiVQ11V11XVE1X1nSUHAuD/eyN71A8kObvUIABc3kqhrqqbkxxL8tCy4wBwqVX3qL+c5HNJ/vhaC1TV8ao6XVWnz58/fzVmAyArhLqqPpzkV9195vWW6+6T3b3X3Xs7OztXbUCAbbfKHvVdST5SVeeSfCvJ3VX1jUWnAuBVVwx1d3++u2/u7t0k9yb5fnfft/hkACRxHjXAeEfeyMLd/cMkP1xkEgAuyx41wHBCDTCcUAMMJ9QAwwk1wHBCDTCcUAMMJ9QAwwk1wHBCDTCcUAMMJ9QAwwk1wHBCDTCcUAMMJ9QAwwk1wHBv6BNeuDbtnnh08XWce/DY4uuA13OYX+f2qAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYDihBhhOqAGGE2qA4YQaYLgrhrqqbqmqH1TV01X1VFU9sI7BANi3yofbvpLks939eFX9eZIzVfWf3f30wrMBkBX2qLv7xe5+/ODvv09yNslNSw8GwL5V9qhfVVW7Se5I8thlHjue5HiSHD169GrMtnaH+ePkDyvfc7iyld9MrKq3Jfl2kk939+8ufby7T3b3Xnfv7ezsXM0ZAbbaSqGuqjdlP9IPd/cjy44EwMVWOeujknwtydnu/tLyIwFwsVX2qO9Kcn+Su6vqyYM/f7fwXAAcuOKbid39X0lqDbMAcBmuTAQYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYTqgBhhNqgOGEGmA4oQYYbqVQV9WHquqnVfWzqjqx9FAA/J8rhrqqrkvyL0n+NsntSf6+qm5fejAA9q2yR/3XSX7W3c9098tJvpXko8uOBcAF1d2vv0DVx5J8qLv/8eD2/Un+prs/cclyx5McP7h5W5KfXv1xL+vGJL9e07omsd3bZ1u3fVu2+y+6e+dyDxy5Wmvo7pNJTl6t51tVVZ3u7r11r3fTbPf22dZt39btvtgqhz5eSHLLRbdvPrgPgDVYJdT/neQvq+rWqnpzknuT/NuyYwFwwRUPfXT3K1X1iST/keS6JP/a3U8tPtnq1n64ZQjbvX22ddu3dbtfdcU3EwHYLFcmAgwn1ADDHepQb+Ol7VV1S1X9oKqerqqnquqBTc+0TlV1XVU9UVXf2fQs61JV76iqU1X1k6o6W1Xv2/RM61BVnzl4jf+4qr5ZVW/Z9EybcmhDvcWXtr+S5LPdfXuSO5P805Zs9wUPJDm76SHW7CtJvtvdf5XkPdmC7a+qm5J8Ksled787+ycy3LvZqTbn0IY6W3ppe3e/2N2PH/z999n/ob1ps1OtR1XdnORYkoc2Pcu6VNXbk3wgydeSpLtf7u7fbHSo9TmS5K1VdSTJ9Ul+seF5NuYwh/qmJM9ddPv5bEmwLqiq3SR3JHlsw6Osy5eTfC7JHzc8xzrdmuR8kq8fHPJ5qKpu2PRQS+vuF5J8McmzSV5M8tvu/t5mp9qcwxzqrVZVb0vy7SSf7u7fbXqepVXVh5P8qrvPbHqWNTuS5L1JvtrddyR5Kck1/35MVb0z+78h35rkXUluqKr7NjvV5hzmUG/tpe1V9absR/rh7n5k0/OsyV1JPlJV57J/mOvuqvrGZkdai+eTPN/dF35rOpX9cF/rPpjk5919vrv/kOSRJO/f8Ewbc5hDvZWXtldVZf945dnu/tKm51mX7v58d9/c3bvZ/7f+fndf83tY3f3LJM9V1W0Hd92T5OkNjrQuzya5s6quP3jN35MteBP1tVy1/z1v3Q7Bpe1LuSvJ/Ul+VFVPHtz3z93975sbiYV9MsnDBzskzyT5+IbnWVx3P1ZVp5I8nv0znZ7IFl9K7hJygOEO86EPgK0g1ADDCTXAcEINMJxQAwwn1ADDCTXAcP8LfGMTn5mMWBMAAAAASUVORK5CYII=",
      "text/plain": [
       "<Figure size 432x288 with 1 Axes>"
      ]
     },
     "metadata": {
      "needs_background": "light"
     },
     "output_type": "display_data"
    }
   ],
   "source": [
    "import numpy as np\n",
    "import matplotlib.pyplot as plt\n",
    "data = np.random.default_rng(12345)\n",
    "oxy_nums = data.integers(low=0, high=10, size=10)\n",
    "\n",
    "plt.bar(range(len(oxy_nums)), oxy_nums)\n",
    "plt.show()\n"
   ]
  },
  {
   "cell_type": "markdown",
   "metadata": {},
   "source": [
    "### Velocidad de la nave\n",
    "Muestra los segundos necesarios para pasar de 0 a 11200 metros por segundo, dada la aceleración de la nave en metros por segundo."
   ]
  },
  {
   "cell_type": "code",
   "execution_count": 5,
   "metadata": {},
   "outputs": [
    {
     "name": "stdout",
     "output_type": "stream",
     "text": [
      "Tiempo en segundos para alcanzar la velocidad deseada =  1142.8571428571427\n"
     ]
    }
   ],
   "source": [
    "endVelocity = 11200\n",
    "startVelocity = 0\n",
    "acceleration = 9.8\n",
    "\n",
    "time = (endVelocity - startVelocity) / acceleration\n",
    "print(\"Tiempo en segundos para alcanzar la velocidad deseada = \", time)\n"
   ]
  }
 ],
 "metadata": {
  "interpreter": {
   "hash": "f779eca3a750bafcf59e051e0cedc42f23938d3a08e4ac3411a467126037adc3"
  },
  "kernelspec": {
   "display_name": "Python 3.10.2 64-bit",
   "language": "python",
   "name": "python3"
  },
  "language_info": {
   "codemirror_mode": {
    "name": "ipython",
    "version": 3
   },
   "file_extension": ".py",
   "mimetype": "text/x-python",
   "name": "python",
   "nbconvert_exporter": "python",
   "pygments_lexer": "ipython3",
   "version": "3.10.2"
  },
  "orig_nbformat": 4
 },
 "nbformat": 4,
 "nbformat_minor": 2
}